### PR TITLE
feat: Add basic external configuration system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,31 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+object Versions {
+
+    const val HOPLITE_VERSION = "2.7.0"
+    const val KOTEST_VERSION = "5.5.4"
+    const val MOCKK_VERSION = "1.13.3"
+}
+
+
 plugins {
     kotlin("jvm") version "1.7.20"
 }
 
 group = "xyz.atrius"
-version = "1.0-SNAPSHOT"
+version = "0.1"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation(kotlin("test"))
+    implementation("com.sksamuel.hoplite:hoplite-core:${Versions.HOPLITE_VERSION}")
+    implementation("com.sksamuel.hoplite:hoplite-yaml:${Versions.HOPLITE_VERSION}")
+    implementation("com.sksamuel.hoplite:hoplite-watch:${Versions.HOPLITE_VERSION}")
+
+    testImplementation("io.kotest:kotest-runner-junit5:${Versions.KOTEST_VERSION}")
+    testImplementation("io.mockk:mockk:${Versions.MOCKK_VERSION}")
 }
 
 tasks.test {
@@ -20,5 +33,5 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }

--- a/src/main/kotlin/xyz/atrius/data/config/Config.kt
+++ b/src/main/kotlin/xyz/atrius/data/config/Config.kt
@@ -1,0 +1,18 @@
+package xyz.atrius.data.config
+
+/**
+ * @author Atri
+ *
+ * Definition of an application config file.
+ *
+ * @property T The configuration's property declaration.
+ */
+interface Config<T> {
+
+    /**
+     * Gets the internal configuration object.
+     *
+     * @return The configuration object.
+     */
+    fun retrieve(): T
+}

--- a/src/main/kotlin/xyz/atrius/data/config/ConfigLoaderProvider.kt
+++ b/src/main/kotlin/xyz/atrius/data/config/ConfigLoaderProvider.kt
@@ -1,0 +1,31 @@
+package xyz.atrius.data.config
+
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addResourceSource
+
+/**
+ * @author Atri
+ *
+ * Provides a [ConfigLoader] with the required specifications.
+ */
+object ConfigLoaderProvider {
+
+    /**
+     * Provides a function which can be used to generate a
+     * [FilePropertySource]-based [ConfigLoader].
+     *
+     * @param resource The location of the resource in the JVM classpath.
+     * @param userLocation The location that external file changes are read from.
+     *
+     * @return A new [ConfigLoader] that tracks external file changes.
+     */
+    fun getFileLoader(
+        resource: String,
+        userLocation: String = resource
+    ): ConfigLoader = ConfigLoaderBuilder
+        .default()
+        .addPropertySource(FilePropertySource(userLocation))
+        .addResourceSource(resource)
+        .build()
+}

--- a/src/main/kotlin/xyz/atrius/data/config/FilePropertySource.kt
+++ b/src/main/kotlin/xyz/atrius/data/config/FilePropertySource.kt
@@ -1,0 +1,35 @@
+package xyz.atrius.data.config
+
+import com.sksamuel.hoplite.*
+import com.sksamuel.hoplite.fp.valid
+import java.io.File
+import kotlin.io.path.inputStream
+
+/**
+ * @author Atri
+ *
+ * Hoplite [PropertySource] for reading config changes from a remove file location.
+ *
+ * @property location The location of the remote file source.
+ */
+class FilePropertySource(
+    private val location: String
+) : PropertySource {
+
+    override fun node(context: PropertySourceContext): ConfigResult<Node> {
+        val file = File(location)
+        // If the file does not exist, just use the internal config
+        if (!file.exists()) {
+            return Undefined.valid()
+        }
+        // Pull data from the external file
+        val path = file.toPath()
+        val input = path.inputStream()
+        // Read into live config
+        return context.parsers
+            .locate(file.extension)
+            .map { it.load(input, path.toString()) }
+    }
+
+    override fun source(): String = location
+}

--- a/src/main/kotlin/xyz/atrius/data/config/SystemConfig.kt
+++ b/src/main/kotlin/xyz/atrius/data/config/SystemConfig.kt
@@ -1,0 +1,23 @@
+package xyz.atrius.data.config
+
+import com.sksamuel.hoplite.Masked
+import kotlin.time.Duration
+
+/**
+ * The system configuration file.
+ *
+ * @property accounts
+ *  The set of user accounts that should be mirrored.
+ *
+ * @property refreshInterval
+ *  How often to check the GitHub API for updates.
+ *
+ *  @property accountToken
+ *  The general token of the account you want to mirror
+ *  all your contributions to.
+ */
+data class SystemConfig(
+    val accounts: Set<String>,
+    val refreshInterval: Duration,
+    val accountToken: Masked?
+)

--- a/src/main/kotlin/xyz/atrius/data/config/SystemConfigProvider.kt
+++ b/src/main/kotlin/xyz/atrius/data/config/SystemConfigProvider.kt
@@ -1,0 +1,28 @@
+package xyz.atrius.data.config
+
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.watch.ReloadableConfig
+import com.sksamuel.hoplite.watch.Watchable
+
+/**
+ * @author Atri
+ *
+ * Configuration file referencing the main system config. The configuration file will
+ * update automatically over a set interval provided by the [watcher].
+ *
+ * @property watcher Provides the logic for when the file should be re-checked.
+ * @property loader Provides the location data of the watched file.
+ */
+class SystemConfigProvider(
+    private val watcher: Watchable,
+    private val loader: ConfigLoader
+) : Config<SystemConfig> {
+
+    private val configLoader: ReloadableConfig<SystemConfig> =
+        ReloadableConfig(loader, SystemConfig::class)
+            .addWatcher(watcher)
+            .also { it.subscribe(::println) }
+
+    override fun retrieve(): SystemConfig =
+        configLoader.getLatest()
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+accounts: []
+refresh-interval: 1h
+account-token: null


### PR DESCRIPTION
The provided system will enable the application to read configuration data from a classpath configuration or an externally-defined user-editable file. This will be necessary later when users will need to add their own configuration data.