### PR TITLE
chore: Ignore schema.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ bin/
 ### Mac OS ###
 .DS_Store
 /.idea/
+/src/main/graphql/schema.json


### PR DESCRIPTION
This file can be introspected locally, so storing it here isn't needed.